### PR TITLE
fixed worldgen crash when loading up in a compiled environment.

### DIFF
--- a/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/OceanTemperateLayer.java
+++ b/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/OceanTemperateLayer.java
@@ -182,8 +182,15 @@ public enum OceanTemperateLayer implements ICastleTransformer, IBishopTransforme
 	}
 	
 	@Override
-	public int func_215728_a(IExtendedNoiseRandom<?> context, IArea area, int x, int z) 
+	public int func_215728_a(IExtendedNoiseRandom<?> context, IArea area, int x, int z)
 	{
-		return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context,  area, x, z);
+		//return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context,  area, x, z);
+		
+		if(this == CASTLE) {
+			return this.apply(context, area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+		}
+		else {
+			return this.apply(context, area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+		}
 	}
 }

--- a/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/OuterShoreLayer.java
+++ b/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/OuterShoreLayer.java
@@ -32,6 +32,13 @@ public enum OuterShoreLayer implements ICastleTransformer, IBishopTransformer
 	@Override
 	public int func_215728_a(IExtendedNoiseRandom<?> context, IArea area, int x, int z)
 	{
-		return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context, area, x, z);
+		//return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context,  area, x, z);
+		
+		if(this == CASTLE) {
+			return this.apply(context, area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+		}
+		else {
+			return this.apply(context, area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+		}
 	}
 }

--- a/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/ShoreLayer.java
+++ b/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/ShoreLayer.java
@@ -32,6 +32,13 @@ public enum ShoreLayer implements ICastleTransformer, IBishopTransformer
 	@Override
 	public int func_215728_a(IExtendedNoiseRandom<?> context, IArea area, int x, int z)
 	{
-		return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context, area, x, z);
+		//return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context,  area, x, z);
+		
+		if(this == CASTLE) {
+			return this.apply(context, area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+		}
+		else {
+			return this.apply(context, area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+		}
 	}
 }

--- a/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/TemperateLayer.java
+++ b/src/main/java/com/igteam/immersivegeology/common/world/layer/layers/overworld/TemperateLayer.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 
 import static com.igteam.immersivegeology.common.world.layer.IGLayerUtil.*;
 
+@SuppressWarnings("unused")
 public enum TemperateLayer implements ICastleTransformer, IBishopTransformer
 {
 	CASTLE, BISHOP;
@@ -419,9 +420,17 @@ public enum TemperateLayer implements ICastleTransformer, IBishopTransformer
 		return center;
 	}
 	
-	@Override
-	public int func_215728_a(IExtendedNoiseRandom<?> context, IArea area, int x, int z) 
-	{
-		return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context,  area, x, z);
-	}
+		@Override
+		public int func_215728_a(IExtendedNoiseRandom<?> context, IArea area, int x, int z)
+		{
+			//return this == CASTLE ? ICastleTransformer.super.func_215728_a(context, area, x, z) : IBishopTransformer.super.func_215728_a(context,  area, x, z);
+			
+			if(this == CASTLE) {
+				return this.apply(context, area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 1)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+			}
+			else {
+				return this.apply(context, area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 2)), area.getValue(this.func_215721_a(x + 2), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 0), this.func_215722_b(z + 0)), area.getValue(this.func_215721_a(x + 1), this.func_215722_b(z + 1)));
+			}
+		}
+	
 }


### PR DESCRIPTION
while loading up a new world in an environment other than the development one the game would crash, calling an error on func_202792_ in certain layer files. this was due to it supering to a method that was after compiling considered abstract. replacing the super with the code the method contained resolved the issue presumably without changing functionality.